### PR TITLE
feat: add listing of tools, prompts, and resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,10 @@ The following variables can be set in the environment.
 | `MCPSERVER_PATH` | Default path for server endpoint | `/mcp` |
 | `MCPSERVER_TOKEN` | Token to use for testing | unset |
 
-## Examples
 
-### Simple Echo
+## Usage
+
+### Start the Server
 
 Start the server in one terminal. Export `MCPSERVER_TOKEN` if you want some client to use simple token auth.
 Leave out the token for local test. Here is an example for http.
@@ -99,12 +100,38 @@ Leave out the token for local test. Here is an example for http.
 mcpserver start --transport http --port 8089
 ```
 
-In another terminal, check the health endpoint or do a simple tool request.
+## Endpoints
+
+In addition to standard MCP endpoints that deliver JSON RPC according to [the specification](https://modelcontextprotocol.io/specification/2025-03-26/basic), we provide a set of more easily accessible http endpoints for easy access to server health or metadata.
+
+### Health Check
 
 ```bash
 # Health check
 curl -s http://0.0.0.0:8089/health  | jq
+```
 
+### Listing
+
+You can list tools, prompts, and resources.
+
+```bash
+curl -s http://0.0.0.0:8089/tools/list  | jq
+curl -s http://0.0.0.0:8089/prompts/list  | jq
+curl -s http://0.0.0.0:8089/resources/list  | jq
+```
+
+We do this internally in the server via discovery by the manager, and then returning a simple JSON response of those found.
+
+## Examples
+
+All of these can be run from a separate terminal when the server is running.
+
+### Simple Echo
+
+Do a simple tool request.
+
+```bash
 # Tool to echo back message
 python3 examples/echo/test_echo.py
 ```

--- a/mcpserver/routes/views.py
+++ b/mcpserver/routes/views.py
@@ -4,5 +4,58 @@ from mcpserver.app import mcp
 
 
 @mcp.custom_route("/health", methods=["GET"])
-async def health_check(request):
+async def health_check(_):
     return JSONResponse({"status": 200, "message": "OK"})
+
+
+@mcp.custom_route("/tools/list", methods=["GET"])
+async def list_tools(_):
+    """
+    Courtesy function to get the same JSON structure as the MCP JSON-RPC tools/list
+    """
+    # FastMCP stores its tools in a list of Tool objects
+    tools = await mcp._tool_manager.get_tools()
+    return JSONResponse(
+        {
+            "tools": [
+                {"name": tool.name, "description": tool.description, "inputSchema": tool.parameters}
+                for _, tool in tools.items()
+            ]
+        }
+    )
+
+
+@mcp.custom_route("/prompts/list", methods=["GET"])
+async def list_prompts(_):
+    """List prompts, ditto above"""
+    prompts = await mcp._prompt_manager.get_prompts()
+    return JSONResponse(
+        {
+            "prompts": [
+                {
+                    "name": tool.name,
+                    "description": tool.description,
+                }
+                for _, tool in prompts.items()
+            ]
+        }
+    )
+
+
+@mcp.custom_route("/resources/list", methods=["GET"])
+async def list_resources(_):
+    """And resources! I haven't tested this one yet."""
+    resources = await mcp._resource_manager.get_resources()
+    return JSONResponse(
+        {
+            "resources": [
+                {
+                    "name": tool.name,
+                    "description": tool.description,
+                    # This is untested, we don't have resources yet
+                    "mimeType": tool.mime_type,
+                }
+                for _, tool in resources.items()
+            ]
+        }
+    )

--- a/mcpserver/version.py
+++ b/mcpserver/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "mcp-serve"


### PR DESCRIPTION
The MCP spec (JSON RPC) provides these endpoints, but it often is easier to do a standard curl (http request) without thinking about that.